### PR TITLE
RFC - show login only when on the correct realm

### DIFF
--- a/resources/public/js/controllers.js
+++ b/resources/public/js/controllers.js
@@ -741,6 +741,7 @@ hsboxControllers.controller('Settings', function ($scope, $http, $rootScope) {
 
 hsboxControllers.controller('Navbar', function ($scope, $http, $interval, $rootScope) {
     $rootScope.isAuthorized = false;
+    $rootScope.showLogin = true;
     $scope.active = 'player_list';
     $scope.version = '';
     $scope.newVersionAvailable = false;
@@ -758,6 +759,7 @@ hsboxControllers.controller('Navbar', function ($scope, $http, $interval, $rootS
     $rootScope.getAuthorizationState = function() {
         $http.get(serverUrl + '/authorized').success(function(data) {
             $rootScope.isAuthorized = data.authorized;
+            $rootScope.showLogin = data.showLogin;
         });
     };
 

--- a/resources/public/templates/navbar.html
+++ b/resources/public/templates/navbar.html
@@ -11,7 +11,7 @@
       <ul class="nav navbar-nav">
         <li ng-class="{active: $scope.active == 'player_list'}"><a href="#/player_list" ng-click="$scope.active = 'player_list'"><i class="fa fa-users"></i> Player List<span class="sr-only">(current)</span></a></li>
         <li ng-class="{active: $scope.active == 'settings'}"><a href="#/settings" ng-click="$scope.active = 'settings'"><i class="fa fa-cogs"></i> Settings</a></li>
-        <li>
+        <li ng-if="showLogin">
           <div ng-switch="isAuthorized" class="my-nav-button">
             <a ng-switch-when="hsbox.handler/admin" href="/openid/logout">Log out</a>
 

--- a/src/hsbox/handler.clj
+++ b/src/hsbox/handler.clj
@@ -104,7 +104,14 @@
            (GET "/authorized" request (response {:authorized
                                                  (if (empty? @openid-settings)
                                                    true
-                                                   (friend/authorized? #{::admin} (friend/identity request)))}))
+                                                   (friend/authorized? #{::admin} (friend/identity request)))
+                                                 :showLogin 
+                                                 (if (empty? @openid-settings)
+                                                  false
+                                                  (if (re-matches (java.util.regex.Pattern/compile (str "htt.*://" (:server-name request) ".*")) (:realm @openid-settings)) 
+                                                    true
+                                                    false))
+                                                }))
            (GET "/version" []
              (response {:current (version/get-version)
                         :latest  @version/latest-version}))


### PR DESCRIPTION
"Invalid login realm" currently ends on a blank page for a user. (+exception in console)
- Login is only needed for the Administrator.

What this patch does:
- accessing the page with a domain other than the configured realm HIDES the login/logout buttons.

What this can be used for:
- allows a "hidden" backend domain + a cached frontend domain
- users potentially logging in from the cached domain is blocked, so a global cache rule can be used
-- startup with realm "hsbox-private.tld" - use to login & configure
-- proxy web users on "hsbox.tld" - login not shown

Tested with and without configured openid