### PR TITLE
fix notes after making watch for local only

### DIFF
--- a/src/hsbox/handler.clj
+++ b/src/hsbox/handler.clj
@@ -79,13 +79,14 @@
                           (response (stats/get-demo-details demoid)))
                         (GET "/notes" []
                           (response {:notes (db/get-demo-notes demoid)}))
-                        (only-local
+                        (context "/watch" []
+                         (only-local
                           (authorize-admin
-                            (POST "/watch" {{steamid :steamid round :round tick :tick highlight :highlight} :body}
+                            (POST "/" {{steamid :steamid round :round tick :tick highlight :highlight} :body}
                               (let [info (launch/watch demoid (Long/parseLong steamid) round tick highlight)]
                                 (if info
                                   (response info)
-                                  (not-found ""))))))
+                                  (not-found "")))))))
                         (authorize-admin
                           (POST "/notes" {body :body}
                             (response (db/set-demo-notes demoid (:notes body)))))))


### PR DESCRIPTION
fixes /notes getting trapped into only-local
ref: https://github.com/bugdone/headshotbox/commit/a2de524a3cb68dd03f4b3717582d7958065d162d 