### PR TITLE
WEBmode - webserver support to allow "watch"

### DIFF
--- a/resources/public/js/controllers.js
+++ b/resources/public/js/controllers.js
@@ -703,6 +703,7 @@ hsboxControllers.controller('Settings', function ($scope, $http, $rootScope) {
     $scope.steamApiCollapsed = true;
     $scope.demoDirectoryCollapsed = true;
     $scope.vdmCollapsed = true;
+    $scope.demowebmodeCollapsed = true;
     $scope.getSettings = function() {
         $http.get(serverUrl + '/config').success(function(data) {
             $scope.config = data;

--- a/resources/public/templates/settings.html
+++ b/resources/public/templates/settings.html
@@ -75,13 +75,33 @@
 
             <h4>Demo Playback</h4>
             <div class="form-group input-group">
-              <span class="input-group-addon"><input type="checkbox" ng-model="config.playdemo_kill_csgo"></span>
-              <span class="form-control">Kill CSGO if running before playing a demo</span>
+              <span class="input-group-addon"><input type="checkbox" ng-model="config.demowebmode"></span>
+              <span class="form-control">Run in WEB-mode (for Servers)</span>
+              <span class="input-group-addon" id="demowebmode-help">
+                <button type="button"
+                        class="btn btn-default btn-xs glyphicon glyphicon-question-sign"
+                        ng-click="demowebmodeCollapsed = !demowebmodeCollapsed">
+                </button>
+              </span>
+            </div>
+            <div collapse="demowebmodeCollapsed">
+              <div class="well well-lg text-left">
+                If you are running Headshotbox on a public server enabling this setting will allow the <em>watch</em> links to work.<br />
+                -> This expects the user to <em>download</em> the demo and save it to the <em>CSGO/replays</em> folder.<br />
+                <i>(SteamApps\common\Counter-Strike Global Offensive\csgo\replays)</i><br />
+                <br />
+                <b>This will also disable the VDM scripting below as these files are not downloaded by the user.</b>
+              </div>
             </div>
 
             <div class="form-group input-group">
-              <span class="input-group-addon"><input type="checkbox" ng-model="config.vdm_enabled"></span>
-              <span class="form-control">Enable VDM scripting</span>
+              <span class="input-group-addon"><input type="checkbox" ng-model="config.playdemo_kill_csgo" ng-disabled="config.demowebmode"></span>
+              <span class="form-control" ng-disabled="config.demowebmode">Kill CSGO if running before playing a demo</span>
+            </div>
+
+            <div class="form-group input-group">
+              <span class="input-group-addon"><input type="checkbox" ng-model="config.vdm_enabled" ng-disabled="config.demowebmode"></span>
+              <span class="form-control" ng-disabled="config.demowebmode">Enable VDM scripting</span>
               <span class="input-group-addon" id="vdm-help">
                 <button type="button"
                         class="btn btn-default btn-xs glyphicon glyphicon-question-sign"
@@ -109,16 +129,16 @@
             </div>
 
             <div class="form-group input-group">
-              <span class="input-group-addon" ng-disabled="!config.vdm_enabled">cfg to execute</span>
+              <span class="input-group-addon" ng-disabled="!config.vdm_enabled || config.demowebmode">cfg to execute</span>
               <input type="text"
                      class="form-control"
                      ng-model="config.vdm_cfg"
-                     ng-disabled="!config.vdm_enabled">
+                     ng-disabled="!config.vdm_enabled || config.demowebmode">
             </div>
 
             <div class="form-group input-group">
-              <span class="input-group-addon"><input type="checkbox" ng-model="config.vdm_quit_after_playback" ng-disabled="!config.vdm_enabled"></span>
-              <span class="form-control" ng-disabled="!config.vdm_enabled">Quit on round end</span>
+              <span class="input-group-addon"><input type="checkbox" ng-model="config.vdm_quit_after_playback" ng-disabled="!config.vdm_enabled || config.demowebmode"></span>
+              <span class="form-control" ng-disabled="!config.vdm_enabled || config.demowebmode">Quit on round end</span>
               </span>
             </div>
 


### PR DESCRIPTION
Implements "WEB-mode" setting. **default is OFF**

When enabled:
- "watch" links will be returned as "replays/..." 
- VDM-scripting gets disabled.
- the localhost-only restriction on "watch" is removed.
so it expects the user to download the demo and save it to the CSGO/replays folder first.

When not enabled: (default)
- "watch" contains absolute paths (i.e. demoLib on a different harddisk)
- "watch" only works for localhost as before


Addresses #95