### PR TITLE
add parameter demoinfo-dir (defaults to current dir)

### DIFF
--- a/src/hsbox/core.clj
+++ b/src/hsbox/core.clj
@@ -3,6 +3,7 @@
             [hsbox.db :as db]
             [hsbox.version :as version]
             [hsbox.indexer :as indexer]
+            [hsbox.demo :refer [set-demoinfo-dir]]
             [hsbox.stats :as stats]
             [ring.adapter.jetty]
             [clojure.string :as string]
@@ -24,6 +25,7 @@
    [nil "--no-indexer" "Does not parse new demos from the demo directory"]
    [nil "--admin-steamid steamid64" "Changing settings and adding notes requires logging in with this steamid64"]
    [nil "--openid-realm url" "Realm url used by OpenID"]
+   [nil "--demoinfo-dir directory" "Directory where demoinfogo is located (default is current dir)"]
    ["-h" "--help"]
    ])
 
@@ -40,12 +42,15 @@
   (try
     (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)
           portable? (:portable options)
-          run-indexer? (not (:no-indexer options))]
+          run-indexer? (not (:no-indexer options))
+          demoinfo-dir (:demoinfo-dir options)]
       (cond (:help options) (exit 0 summary)
             errors (exit 1 (str summary (error-msg errors))))
 
       (when portable?
         (db/set-portable))
+      (when (not-empty demoinfo-dir)
+        (set-demoinfo-dir demoinfo-dir))
       (timbre/set-config! [:shared-appender-config :spit-filename] (File. db/app-config-dir "headshotbox.log"))
       (info "HeadshotBox" (version/get-version) (if portable? "portable" "")
             (if (not run-indexer?) "no indexer" ""))

--- a/src/hsbox/demo.clj
+++ b/src/hsbox/demo.clj
@@ -14,6 +14,7 @@
 (import Cstrike15Gcmessages$CDataGCCStrike15_v2_MatchInfo)
 (def MatchInfo (protodef Cstrike15Gcmessages$CDataGCCStrike15_v2_MatchInfo))
 (def PARSER-CACHE nil)
+(def demoinfo-dir-path (System/getProperty "user.dir"))
 
 (defn read-file [file-path]
   (with-open [reader (input-stream file-path)]
@@ -37,11 +38,17 @@
 (defn get-parser-cache []
   (get (System/getenv) "HEADSHOTBOX_PARSER_CACHE" PARSER-CACHE))
 
+(defn get-demoinfo-dir []
+  demoinfo-dir-path)
+
+(defn set-demoinfo-dir [dir]
+  (def demoinfo-dir-path dir))
+
 (defn parse-demo [path]
   (let [json-cache (get-parser-cache)
         json-path (str json-cache "/" (.getName (as-file path)) ".json")
         do-parse (fn []
-                   (let [proc (clojure.java.shell/sh (str (System/getProperty "user.dir") "/demoinfogo") path "-hsbox")]
+                   (let [proc (clojure.java.shell/sh (str (get-demoinfo-dir) "/demoinfogo") path "-hsbox")]
                      (assert (zero? (:exit proc)))
                      (:out proc)))]
     (if (nil? json-cache)


### PR DESCRIPTION
Implements (optional) command line param `--demoinfo-dir path`
If not set defaulting to "current dir" (as before)

Usefull when starting the jar via systemd.