### PR TITLE
Added locale to toLocaleString in timestamp2Date

### DIFF
--- a/resources/public/js/controllers.js
+++ b/resources/public/js/controllers.js
@@ -62,7 +62,12 @@ function timestamp2date(timestamp, only_date) {
     }
     if (d.getFullYear() != (new Date()).getFullYear())
         format.year = 'numeric';
-    return d.toLocaleString('en-US', format);
+    
+    var language = navigator.languages && navigator.languages[0] ||
+               navigator.language ||
+               navigator.userLanguage;
+        
+    return d.toLocaleString(language, format);
 };
 
 function date2timestamp(date) {

--- a/resources/public/js/controllers.js
+++ b/resources/public/js/controllers.js
@@ -62,7 +62,7 @@ function timestamp2date(timestamp, only_date) {
     }
     if (d.getFullYear() != (new Date()).getFullYear())
         format.year = 'numeric';
-    return d.toLocaleString(undefined, format);
+    return d.toLocaleString('en-US', format);
 };
 
 function date2timestamp(date) {


### PR DESCRIPTION
This should fix the issue where Chrome prints out M01, M02 etc for the month name.
Passing in an undefined locale causes this error.